### PR TITLE
Add initial FastAPI backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
-# codex_2025_06_25
+# Mentor Matching App
+
+This repository contains a minimal FastAPI backend implementing part of the "AI-Personalized Mentor Matching Platform for Programming" concept.
+
+## Setup
+
+1. Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+2. Run the development server:
+
+```bash
+uvicorn app.main:app --reload
+```
+
+The API will be available at `http://localhost:8000/`.
+
+## Available Endpoints
+
+- `POST /users/` – create a user (student or teacher).
+- `POST /teacher_profiles/` – create a teacher profile linked to a user.
+- `POST /curriculums/` – create a curriculum for a student.
+
+These are initial endpoints and serve as a foundation for further development of the matching platform.

--- a/app/crud.py
+++ b/app/crud.py
@@ -1,0 +1,46 @@
+from sqlalchemy.orm import Session
+from . import models, schemas
+from datetime import datetime
+from passlib.context import CryptContext
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+def get_password_hash(password: str) -> str:
+    return pwd_context.hash(password)
+
+# Users
+
+def create_user(db: Session, user: schemas.UserCreate) -> models.User:
+    db_user = models.User(
+        name=user.name,
+        email=user.email,
+        hashed_password=get_password_hash(user.password),
+        role=user.role,
+    )
+    db.add(db_user)
+    db.commit()
+    db.refresh(db_user)
+    return db_user
+
+# Teacher profile
+
+def create_teacher_profile(db: Session, profile: schemas.TeacherProfileCreate) -> models.TeacherProfile:
+    db_profile = models.TeacherProfile(**profile.dict())
+    db.add(db_profile)
+    db.commit()
+    db.refresh(db_profile)
+    return db_profile
+
+# Curriculum
+
+def create_curriculum(db: Session, curriculum: schemas.CurriculumCreate) -> models.Curriculum:
+    db_curriculum = models.Curriculum(
+        student_id=curriculum.student_id,
+        roadmap=curriculum.roadmap,
+        created_at=datetime.utcnow(),
+    )
+    db.add(db_curriculum)
+    db.commit()
+    db.refresh(db_curriculum)
+    return db_curriculum
+

--- a/app/database.py
+++ b/app/database.py
@@ -1,0 +1,13 @@
+from sqlalchemy import create_engine
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import sessionmaker
+
+SQLALCHEMY_DATABASE_URL = "sqlite:///./test.db"
+
+engine = create_engine(
+    SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False}
+)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+Base = declarative_base()
+

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,34 @@
+from fastapi import FastAPI, Depends, HTTPException
+from sqlalchemy.orm import Session
+from . import models, schemas, crud
+from .database import engine, SessionLocal
+
+models.Base.metadata.create_all(bind=engine)
+
+app = FastAPI(title="Mentor Matching API")
+
+# Dependency to get DB session
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+@app.post("/users/", response_model=schemas.User)
+def create_user(user: schemas.UserCreate, db: Session = Depends(get_db)):
+    return crud.create_user(db, user)
+
+@app.post("/teacher_profiles/", response_model=schemas.TeacherProfile)
+def create_profile(profile: schemas.TeacherProfileCreate, db: Session = Depends(get_db)):
+    return crud.create_teacher_profile(db, profile)
+
+@app.post("/curriculums/", response_model=schemas.Curriculum)
+def create_curriculum(curriculum: schemas.CurriculumCreate, db: Session = Depends(get_db)):
+    return crud.create_curriculum(db, curriculum)
+
+@app.get("/")
+def read_root():
+    return {"message": "Mentor Matching API"}
+

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,60 @@
+from sqlalchemy import Column, Integer, String, ForeignKey, DateTime, Text
+from sqlalchemy.orm import relationship
+from .database import Base
+
+class User(Base):
+    __tablename__ = "users"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, nullable=False)
+    email = Column(String, unique=True, index=True, nullable=False)
+    hashed_password = Column(String, nullable=False)
+    role = Column(String, nullable=False)  # 'student' or 'teacher'
+
+    teacher_profile = relationship("TeacherProfile", back_populates="user", uselist=False)
+
+class TeacherProfile(Base):
+    __tablename__ = "teacher_profiles"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(Integer, ForeignKey("users.id"))
+    skills = Column(Text)
+    experience = Column(Text)
+    introduction = Column(Text)
+    rate = Column(Integer)
+
+    user = relationship("User", back_populates="teacher_profile")
+
+class Curriculum(Base):
+    __tablename__ = "curriculums"
+
+    id = Column(Integer, primary_key=True, index=True)
+    student_id = Column(Integer, ForeignKey("users.id"))
+    roadmap = Column(Text)
+    created_at = Column(DateTime)
+
+class Match(Base):
+    __tablename__ = "matches"
+
+    id = Column(Integer, primary_key=True, index=True)
+    student_id = Column(Integer, ForeignKey("users.id"))
+    teacher_id = Column(Integer, ForeignKey("users.id"))
+    status = Column(String)
+
+class Lesson(Base):
+    __tablename__ = "lessons"
+
+    id = Column(Integer, primary_key=True, index=True)
+    match_id = Column(Integer, ForeignKey("matches.id"))
+    lesson_date = Column(DateTime)
+    notes = Column(Text)
+    status = Column(String)
+
+class Chat(Base):
+    __tablename__ = "chats"
+
+    id = Column(Integer, primary_key=True, index=True)
+    match_id = Column(Integer, ForeignKey("matches.id"))
+    sender_id = Column(Integer, ForeignKey("users.id"))
+    message_content = Column(Text)
+

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -1,0 +1,48 @@
+from datetime import datetime
+from typing import Optional
+from pydantic import BaseModel, EmailStr
+
+class UserBase(BaseModel):
+    name: str
+    email: EmailStr
+    role: str
+
+class UserCreate(UserBase):
+    password: str
+
+class User(UserBase):
+    id: int
+
+    class Config:
+        orm_mode = True
+
+class TeacherProfileBase(BaseModel):
+    skills: Optional[str] = None
+    experience: Optional[str] = None
+    introduction: Optional[str] = None
+    rate: Optional[int] = None
+
+class TeacherProfileCreate(TeacherProfileBase):
+    user_id: int
+
+class TeacherProfile(TeacherProfileBase):
+    id: int
+    user_id: int
+
+    class Config:
+        orm_mode = True
+
+class CurriculumBase(BaseModel):
+    student_id: int
+    roadmap: str
+
+class CurriculumCreate(CurriculumBase):
+    pass
+
+class Curriculum(CurriculumBase):
+    id: int
+    created_at: datetime
+
+    class Config:
+        orm_mode = True
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+fastapi
+uvicorn
+sqlalchemy
+pydantic
+passlib[bcrypt]


### PR DESCRIPTION
## Summary
- initialize FastAPI project with database models
- provide CRUD helpers and minimal API endpoints
- document setup and usage in README
- include requirements.txt

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68425602dacc832faaa08c56b37836d4